### PR TITLE
Introducing install tags

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,16 +3,22 @@
   get_url:
     url: "{{ aws_inspector_url }}"
     dest: "{{ aws_inspector_installer_dest }}"
+  tags:
+    - install
 
 - name: Ensure AWS Inspector agent is installed.
   command: bash "{{ aws_inspector_installer_dest }}"
   args:
     creates: "/etc/init.d/awsagent"
   when: not aws_inspector_role_test_mode
-
+  tags:
+    - install
+    
 - name: Ensure awsagent service is running.
   service:
     name: awsagent
     state: "{{ awsagent_state }}"
     enabled: true
   when: not aws_inspector_role_test_mode
+  tags:
+    - always


### PR DESCRIPTION
Added install tags to have a granularity over the execution of the playbook.
It will make the playbook reusable in a context of immutable infrastructure, where no installation takes place.